### PR TITLE
use https:// for submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "haskeline-class"]
 	path = haskeline-class
-	url = git@github.com:derrickturk/haskeline-class.git
+	url = https://github.com/derrickturk/haskeline-class.git


### PR DESCRIPTION
The git@github.com url wasn't working for me, I got this error: "Permission denied (publickey)". So changed it to use https, and it worked. I had to re-clone the repository first though.